### PR TITLE
Fix LogisticSwaps by updating ExpyXBnoji correctly

### DIFF
--- a/src/CDL012LogisticSwaps.cpp
+++ b/src/CDL012LogisticSwaps.cpp
@@ -110,8 +110,13 @@ FitResult<T> CDL012LogisticSwaps<T>::_Fit() {
                     }
                     
                     
-                    Btemp[i] = Binew;
-                    ObjTemp = Objective(ExpyXBnoji, Btemp);
+                    if (ObjTemp >= Fmin) {
+                        ExpyXBnoji %= arma::exp( (Binew - Biold) *  matrix_column_get(*Xy, i));
+                        Btemp[i] = Binew;
+                        ObjTemp = Objective(ExpyXBnoji, Btemp);
+                    } else {
+                        Binew = 0;
+                    }
                     
                     if (ObjTemp < Fmin) {
                         Fmin = ObjTemp;


### PR DESCRIPTION
The reason for doing this is that during the for-loop between lines 94-110, the update of 'ExpyXBnoji' always lags behind the update of 'Binew' by 1 step. Therefore, the final 'ExpyXBnoji' corresponds to the value at t-1 step, not the t step. However, Binew has been updated by t steps. This code fix should also work in the case that ObjTemp < Fmin and the algorithm skips over the for-loop between lines 94-100.