### PR TITLE
Implement supportSize field for `coef`

### DIFF
--- a/R/coef.R
+++ b/R/coef.R
@@ -2,9 +2,12 @@
 #'
 #' @description Extracts a specific solution in the regularization path.
 #' @param object The output of L0Learn.fit or L0Learn.cvfit
-#' @param ... ignore
 #' @param lambda The value of lambda at which to extract the solution.
 #' @param gamma The value of gamma at which to extract the solution.
+#' @param supportSize The number of non-zeros each solution extracted will
+#' contain. If no solutions have `supportSize` non-zeros, solutions with
+#' the closest number will be extracted.
+#' @param ... ignore
 #' @method coef L0Learn
 #' @details
 #' If both lambda and gamma are not supplied, then a matrix of coefficients
@@ -16,47 +19,80 @@
 #' X = data$X
 #' y = data$y
 #'
-#' # Fit an L0L2 Model with 10 values of Gamma ranging from 0.0001 to 10, using coordinate descent
-#' fit <- L0Learn.fit(X, y, penalty="L0L2", maxSuppSize=50, nGamma=10, gammaMin=0.0001, gammaMax = 10)
+#' # Fit an L0L2 Model with 10 values of Gamma ranging from 0.0001 to 10,
+#' # using coordinate descent
+#' fit <- L0Learn.fit(X, y, penalty="L0L2", maxSuppSize=50,
+#'                    nGamma=10, gammaMin=0.0001, gammaMax = 10)
 #' print(fit)
-#' # Extract the coefficients of the solution at lambda = 0.0361829 and gamma = 0.0001
+#' # Extract the coefficients of the solution at lambda = 0.0361829
+#' # and gamma = 0.0001
 #' coef(fit, lambda=0.0361829, gamma=0.0001)
 #' # Extract the coefficients of all the solutions in the path
 #' coef(fit)
-#'
+#' # Extract the coefficients of the solution at supportSize = 10
+#' # and gamma = 0.0001
+#' coef(fit, supportSize=10, gamma=0.0001)
 #' @export
-coef.L0Learn <- function(object,lambda=NULL,gamma=NULL, ...){
-		if (is.null(lambda) && is.null(gamma)){
-				t = do.call(cbind,object$beta)
-				if (object$settings$intercept){
-						intercepts = unlist(object$a0)
-						t = rbind(intercepts, t)
-				}
-		}
-		else{
-				if (is.null(gamma)){ # if lambda is present but gamma is not, use smallest value of gamma
-						gamma = object$gamma[1]
-				}
-				diffGamma = abs(object$gamma-gamma)
-				gammaindex = which(diffGamma==min(diffGamma))
-				diffLambda = abs(lambda - object$lambda[[gammaindex]])
-				indices = which(diffLambda == min(diffLambda))
-				#indices = match(lambda,object$lambda[[gammaindex]])
-				if (object$settings$intercept){
-						t = rbind(object$a0[[gammaindex]][indices],object$beta[[gammaindex]][,indices,drop=FALSE])
-						rownames(t) = c("Intercept",paste(rep("V",object$p),1:object$p,sep=""))
-				}
-				else{
-						t = object$beta[[gammaindex]][,indices,drop=FALSE]
-						rownames(t) = paste(rep("V",object$p),1:object$p,sep="")
-				}
-		}
-		t
-}
+coef.L0Learn <- function(object,
+                         lambda = NULL,
+                         gamma = NULL,
+                         supportSize = NULL, ...) {
+    if (!is.null(supportSize) && !is.null(lambda)) {
+        stop("If `supportSize` is provided to `coef` only `gamma` can also be provided.")
+    }
+    
+    
+    if (is.null(lambda) && is.null(gamma) && is.null(supportSize)) {
+        # If all three are null, return all solutions
+        t <- do.call(cbind, object$beta)
+        if (object$settings$intercept) {
+            intercepts <- unlist(object$a0)
+            t <- rbind(intercepts, t)
+        }
+        return(t)
+    }
+        
+    if (is.null(gamma)) {
+        # if lambda is present but gamma is not, use smallest value of gamma
+        gamma <- object$gamma[1]
+    }
+    
+    diffGamma <- abs(object$gamma - gamma)
+    gammaindex <- which(diffGamma == min(diffGamma))
 
+    indices <- NULL
+    if (!is.null(lambda)) {
+        diffLambda <- abs(lambda - object$lambda[[gammaindex]])
+        indices <- which(diffLambda == min(diffLambda))
+    } else if(!is.null(supportSize)) {
+        diffSupportSize <- abs(supportSize - object$suppSize[[gammaindex]])
+        indices <- which(diffSupportSize == min(diffSupportSize))
+    } else {
+        indices <- seq_along(object$lambda[[gammaindex]])
+    }
+
+    if (object$settings$intercept) {
+        t <- rbind(object$a0[[gammaindex]][indices],
+                   object$beta[[gammaindex]][, indices, drop = FALSE])
+        rownames(t) <- c("Intercept",
+                         paste(rep("V", object$p),
+                               1:object$p,
+                               sep = ""))
+    } else {
+        t <- object$beta[[gammaindex]][, indices, drop = FALSE]
+        rownames(t) <- paste(rep("V", object$p),
+                             1:object$p,
+                             sep = "")
+    }
+
+    t
+}
+    
+    
 #' @rdname coef.L0Learn
 #' @method coef L0LearnCV
 #' @export
-coef.L0LearnCV <- function(object,lambda=NULL,gamma=NULL, ...){
-    coef.L0Learn(object$fit,lambda,gamma, ...)
+coef.L0LearnCV <- function(object, lambda=NULL, gamma=NULL, ...) {
+    coef.L0Learn(object$fit, lambda, gamma, ...)
 }
+    

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // L0LearnFit_sparse
 Rcpp::List L0LearnFit_sparse(const arma::sp_mat& X, const arma::vec& y, const std::string Loss, const std::string Penalty, const std::string Algorithm, const std::size_t NnzStopNum, const std::size_t G_ncols, const std::size_t G_nrows, const double Lambda2Max, const double Lambda2Min, const bool PartialSort, const std::size_t MaxIters, const double rtol, const double atol, const bool ActiveSet, const std::size_t ActiveSetNum, const std::size_t MaxNumSwaps, const double ScaleDownFactor, const std::size_t ScreenSize, const bool LambdaU, const std::vector< std::vector<double> > Lambdas, const std::size_t ExcludeFirstK, const bool Intercept, const bool withBounds, const arma::vec& Lows, const arma::vec& Highs);
 RcppExport SEXP _L0Learn_L0LearnFit_sparse(SEXP XSEXP, SEXP ySEXP, SEXP LossSEXP, SEXP PenaltySEXP, SEXP AlgorithmSEXP, SEXP NnzStopNumSEXP, SEXP G_ncolsSEXP, SEXP G_nrowsSEXP, SEXP Lambda2MaxSEXP, SEXP Lambda2MinSEXP, SEXP PartialSortSEXP, SEXP MaxItersSEXP, SEXP rtolSEXP, SEXP atolSEXP, SEXP ActiveSetSEXP, SEXP ActiveSetNumSEXP, SEXP MaxNumSwapsSEXP, SEXP ScaleDownFactorSEXP, SEXP ScreenSizeSEXP, SEXP LambdaUSEXP, SEXP LambdasSEXP, SEXP ExcludeFirstKSEXP, SEXP InterceptSEXP, SEXP withBoundsSEXP, SEXP LowsSEXP, SEXP HighsSEXP) {


### PR DESCRIPTION
This PR gives `coef` a backward compatible option to `coef`, allowing looking up solutions by closest support size.

A few examples of the new implementation functionality below.

```
> library(L0Learn)
> data <- GenSynthetic(n=500,p=1000,k=25,seed=1)
> fit <- L0Learn.fit(data$X, data$y, penalty="L0L2", maxSuppSize=50, nGamma=3, gammaMin=0.0001, gammaMax = 10)
> fit$suppSize
[[1]]
 [1]  0  1  2  3  4  4 10 10 16 17 17 19 19 21 21 32 34 35 35 41 42 45 47 48 50

[[2]]
 [1]  0  1  2  2  3  4  4  9  9 16 16 25 25 25 25 25 25 25 25 25 25 25 25 25 25
[26] 25 25 25 25 25 25 25 25 25 25 25 26 26 34 34

[[3]]
 [1]  0  1  2  2  2  7  7 12 12 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
[26] 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
[51] 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25 25
[76] 25 25 25 25 25 25 25 25 25 25 25 28 28
>dim(coef(fit, supportSize=10)) # Uses first gamma by default
[1] 1001    2
>fit$gamma
[1] 10.00000000  0.03162278  0.00010000
> dim(coef(fit, supportSize=2, gamma=0.00010000))
[1] 1001    3
>coef(fit, supportSize=2, gamma=0.00010000, lambda=1)
 Error in coef.L0Learn(fit, supportSize = 2, gamma = 1e-04, lambda = 1) : 
If `supportSize` is provided to `coef` only `gamma` can also be provided.
```